### PR TITLE
Fix crash in copy run

### DIFF
--- a/ArchiveToolsLib/Compression/Yaz0Decoder.cs
+++ b/ArchiveToolsLib/Compression/Yaz0Decoder.cs
@@ -73,7 +73,10 @@ namespace WArchiveTools.Compression
                     // Copy Run
                     for (int k = 0; k < numBytes; k++)
                     {
-                        output[destPos] = output[copySource];
+                        if (destPos < uncompressedSize)
+                        {
+                            output[destPos] = output[copySource];
+                        }
                         copySource++;
                         destPos++;
                     }


### PR DESCRIPTION
On some compressed files destPos seems to exceed the last valid index of the output which causes an exception, thus failing to load otherwise valid files. By checking destPos against uncompressedSize that exception can be avoided.